### PR TITLE
ECSエージェントの死活監視システムを新規作成。Terraformモジュールを通じて、ECSエージェントの状態を監視し、停止時に自動的に再…

### DIFF
--- a/ecs/monitoring/README.md
+++ b/ecs/monitoring/README.md
@@ -46,7 +46,7 @@ vi terraform.tfvars
 project_name = "your-project"
 environment  = "dev"
 cluster_arn  = "arn:aws:ecs:region:account:cluster/cluster-name"
-slack_token  = "xoxb-your-slack-bot-token-here"
+slack_token_secret_arn = "arn:aws:secretsmanager:region:account:secret:slack-token-secret-name"
 
 # オプション設定
 slack_channel         = "#alerts"
@@ -79,12 +79,12 @@ terraform destroy
 
 ### 基本設定
 
-| パラメータ     | 説明                                     | デフォルト値 | 必須 |
-| -------------- | ---------------------------------------- | ------------ | ---- |
-| `project_name` | プロジェクト名                           | -            | ✓    |
-| `environment`  | 環境名 (prd, rls, stg, dev)              | -            | ✓    |
-| `cluster_arn`  | 監視対象のECSクラスターARN               | -            | ✓    |
-| `slack_token`  | Slack Bot Token（xoxb-で始まるトークン） | -            | ✓    |
+| パラメータ               | 説明                                                                  | デフォルト値 | 必須 |
+| ------------------------ | --------------------------------------------------------------------- | ------------ | ---- |
+| `project_name`           | プロジェクト名                                                        | -            | ✓    |
+| `environment`            | 環境名 (prd, rls, stg, dev)                                           | -            | ✓    |
+| `cluster_arn`            | 監視対象のECSクラスターARN                                            | -            | ✓    |
+| `slack_token_secret_arn` | Slack Bot Token を格納している AWS Secrets Manager のシークレット ARN | -            | ✓    |
 
 ### オプション設定
 

--- a/ecs/monitoring/README.md
+++ b/ecs/monitoring/README.md
@@ -1,0 +1,207 @@
+# ECSエージェント死活監視システム
+
+このTerraformモジュールは、ECSエージェントの死活監視を自動化するシステムを構築します。ECSエージェントが停止した場合、自動的に再起動を試行し、結果をSlackに通知します。
+
+## 概要
+
+このシステムは以下の流れで動作します：
+
+1. **EventBridge**: ECSコンテナインスタンスの状態変更イベントを監視
+2. **CloudWatch Logs**: イベントをログとして記録
+3. **Lambda関数**: ECSエージェントが停止した場合の自動復旧処理
+4. **Systems Manager**: EC2インスタンスでのECSエージェント再起動コマンド実行
+5. **Slack通知**: Slack SDKを使用した通知
+
+## アーキテクチャ
+
+```
+ECS Container Instance → EventBridge → CloudWatch Logs → Lambda → SSM → Slack
+```
+
+## 前提条件
+
+- AWS CLI v2 がインストールされていること
+- Terraform v1.0以上がインストールされていること
+- Python 3.x および pip がインストールされていること（Lambda依存関係のインストール用）
+- ECSクラスターが既に作成されていること
+- EC2インスタンスにSSMエージェントがインストールされていること
+- Slack Bot Token（xoxb-で始まるトークン）が取得済みであること
+
+## 使用方法
+
+### 1. 設定ファイルの準備
+
+```bash
+# 設定例ファイルをコピー
+cp terraform.tfvars.example terraform.tfvars
+
+# 設定ファイルを編集
+vi terraform.tfvars
+```
+
+### 2. 必要な設定項目
+
+```hcl
+# 必須設定
+project_name = "your-project"
+environment  = "dev"
+cluster_arn  = "arn:aws:ecs:region:account:cluster/cluster-name"
+slack_token  = "xoxb-your-slack-bot-token-here"
+
+# オプション設定
+slack_channel         = "#alerts"
+log_retention_in_days = 30
+lambda_timeout        = 60
+```
+
+### 3. デプロイ
+
+```bash
+# 初期化
+terraform init
+
+# プラン確認
+terraform plan
+
+# 適用
+terraform apply
+```
+
+**注意**: 初回デプロイ時、Lambda関数の依存関係（slack-sdk）が自動的にインストールされます。この処理には数分かかる場合があります。
+
+### 4. 削除
+
+```bash
+terraform destroy
+```
+
+## 設定パラメータ
+
+### 基本設定
+
+| パラメータ     | 説明                                     | デフォルト値 | 必須 |
+| -------------- | ---------------------------------------- | ------------ | ---- |
+| `project_name` | プロジェクト名                           | -            | ✓    |
+| `environment`  | 環境名 (prd, rls, stg, dev)              | -            | ✓    |
+| `cluster_arn`  | 監視対象のECSクラスターARN               | -            | ✓    |
+| `slack_token`  | Slack Bot Token（xoxb-で始まるトークン） | -            | ✓    |
+
+### オプション設定
+
+| パラメータ                    | 説明                       | デフォルト値                           |
+| ----------------------------- | -------------------------- | -------------------------------------- |
+| `aws_region`                  | AWSリージョン              | `ap-northeast-1`                       |
+| `resource_name_prefix`        | リソース名のプレフィックス | `{project_name}-{environment}`         |
+| `slack_channel`               | Slack通知先チャンネル名    | `#alerts`                              |
+| `log_retention_in_days`       | CloudWatchログの保持期間   | `30`                                   |
+| `lambda_timeout`              | Lambda関数のタイムアウト   | `60`                                   |
+| `lambda_runtime`              | Lambda関数のランタイム     | `python3.9`                            |
+| `subscription_filter_pattern` | ログフィルターパターン     | `{ $.detail.agentConnected is false }` |
+| `enable_monitoring`           | 監視の有効/無効            | `true`                                 |
+
+## 出力値
+
+このモジュールは以下の値を出力します：
+
+- `eventbridge_rule_name` - EventBridgeルール名
+- `lambda_function_name` - Lambda関数名
+- `log_group_name` - CloudWatchログ グループ名
+- `subscription_filter_name` - サブスクリプションフィルター名
+
+## 監視対象
+
+このシステムは以下のイベントを監視します：
+
+- ECSコンテナインスタンスの状態変更
+- ECSエージェントの接続状態 (`agentConnected: false`)
+
+## 自動復旧処理
+
+ECSエージェントが停止した場合、以下の処理が実行されます：
+
+1. ECSエージェントの状態確認: `sudo systemctl status ecs`
+2. 停止している場合の再起動: `sudo systemctl start ecs`
+3. 処理結果のSlack通知（Slack SDKを使用）
+
+### Slack通知の内容
+
+システムは以下の2種類の通知を送信します：
+
+**1. 監視アラート通知**
+```
+⚠️ ECS Agent Monitor Alert
+
+Instance ID: i-1234567890abcdef0
+Cluster: my-cluster
+Status: ECS agent disconnected - attempting restart
+Command ID: 12345678-1234-1234-1234-123456789012
+```
+
+**2. エラー通知**
+```
+🔴 ECS Agent Monitor Error
+
+Error: [エラー内容]
+Instance ID: i-1234567890abcdef0
+```
+
+## 主な機能
+
+- **自動復旧**: ECSエージェントが停止した場合、自動的に再起動を試行
+- **Slack通知**: Slack SDKを使用したリッチな通知（絵文字、フォーマット対応）
+- **エラーハンドリング**: 処理エラー時の自動通知
+- **柔軟な設定**: 監視の有効/無効切り替え、ログ保持期間の設定など
+- **セキュリティ**: 最小限の権限でIAMロールとポリシーを設定
+- **依存関係管理**: requirements.txtを使用した自動パッケージ管理（slack-sdk >= 3.19.0）
+
+## 権限
+
+このシステムでは以下のIAM権限が必要です：
+
+### Lambda実行ロール
+- CloudWatch Logs への書き込み権限
+- Systems Manager SendCommand の実行権限
+
+### EC2インスタンス
+- Systems Manager エージェントの実行権限
+- ECSエージェントの管理権限
+
+## トラブルシューティング
+
+### ECSエージェントが再起動しない場合
+
+1. EC2インスタンスでSSMエージェントが動作していることを確認
+2. Lambda関数のログを確認
+3. ECSエージェントの設定を確認
+
+### Slack通知が送信されない場合
+
+1. Slack Bot Tokenが正しいことを確認
+2. Botがチャンネルに追加されていることを確認
+3. Lambda関数の環境変数を確認
+4. ネットワーク設定を確認
+
+### Slack Bot Tokenの取得方法
+
+1. [Slack API](https://api.slack.com/apps)でアプリを作成
+2. 「OAuth & Permissions」から「Bot Token Scopes」に以下の権限を追加：
+   - `chat:write`
+   - `chat:write.public`
+3. 「Install App」からワークスペースにインストール
+4. 「Bot User OAuth Token」（xoxb-で始まるトークン）を取得
+
+### CloudWatch Logsにイベントが記録されない場合
+
+1. EventBridgeルールが有効であることを確認
+2. ECSクラスターARNが正しいことを確認
+3. CloudWatch Logsの権限を確認
+
+## 参考資料
+
+- [AWS ECS Agent 接続解除に関するトラブルシューティング](https://repost.aws/ja/knowledge-center/ecs-agent-disconnected-linux2-ami)
+- [CloudWatch Alarmによるコマンド実行](https://dev.classmethod.jp/articles/run-command-triggerd-by-cloudwatch-alarm/)
+- [ECS Container Instance State Change Events](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs_cwe_events.html)
+
+## ライセンス
+
+このプロジェクトは社内利用のためのものです。

--- a/ecs/monitoring/terraform/main.tf
+++ b/ecs/monitoring/terraform/main.tf
@@ -1,0 +1,468 @@
+# ==================================================
+# ローカル変数
+# ==================================================
+
+locals {
+  # リソース名のプレフィックス
+  name_prefix = var.resource_name_prefix != "" ? var.resource_name_prefix : "${var.project_name}-${var.environment}"
+
+  # EventBridge ルール名
+  eventbridge_rule_name = "${local.name_prefix}-ecs-instance-state-change-rule"
+
+  # CloudWatch ログ グループ名
+  log_group_name = var.log_group_name != "" ? var.log_group_name : "/aws/events/${local.eventbridge_rule_name}"
+
+  # Lambda 関数名
+  lambda_function_name = "${local.name_prefix}-ecs-agent-monitor"
+
+  # Lambda IAM ロール名
+  lambda_role_name = "${local.name_prefix}-ecs-agent-monitor-role"
+
+  # サブスクリプション フィルター名
+  subscription_filter_name = "${local.name_prefix}-ecs-agent-monitor-filter"
+}
+
+# ==================================================
+# データソース
+# ==================================================
+
+data "aws_caller_identity" "current" {}
+
+data "aws_region" "current" {}
+
+# ==================================================
+# EventBridge ルール
+# ==================================================
+
+resource "aws_cloudwatch_event_rule" "ecs_instance_state_change" {
+  count       = var.enable_monitoring ? 1 : 0
+  name        = local.eventbridge_rule_name
+  description = "${var.project_name}のECSインスタンス状態変更取得ルール"
+
+  event_pattern = jsonencode({
+    source      = ["aws.ecs"]
+    detail-type = ["ECS Container Instance State Change"]
+    detail = {
+      clusterArn = [var.cluster_arn]
+    }
+  })
+
+  state = "ENABLED"
+
+  tags = merge(
+    var.common_tags,
+    {
+      Name      = local.eventbridge_rule_name
+      ManagedBy = "Terraform"
+    }
+  )
+}
+
+# ==================================================
+# CloudWatch ログ グループ
+# ==================================================
+
+resource "aws_cloudwatch_log_group" "ecs_agent_monitor" {
+  count             = var.enable_monitoring ? 1 : 0
+  name              = local.log_group_name
+  retention_in_days = var.log_retention_in_days
+
+  tags = merge(
+    var.common_tags,
+    {
+      Name      = local.log_group_name
+      ManagedBy = "Terraform"
+    }
+  )
+}
+
+# ==================================================
+# EventBridge ターゲット（CloudWatch ログ グループ）
+# ==================================================
+
+resource "aws_cloudwatch_event_target" "log_group" {
+  count     = var.enable_monitoring ? 1 : 0
+  rule      = aws_cloudwatch_event_rule.ecs_instance_state_change[0].name
+  target_id = "EcsInstanceStateChangeLogTarget"
+  arn       = aws_cloudwatch_log_group.ecs_agent_monitor[0].arn
+}
+
+# ==================================================
+# Lambda 実行用 IAM ロール
+# ==================================================
+
+resource "aws_iam_role" "lambda_role" {
+  count = var.enable_monitoring ? 1 : 0
+  name  = local.lambda_role_name
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "lambda.amazonaws.com"
+        }
+      }
+    ]
+  })
+
+  tags = merge(
+    var.common_tags,
+    {
+      Name      = local.lambda_role_name
+      ManagedBy = "Terraform"
+    }
+  )
+}
+
+# ==================================================
+# Lambda 基本実行ポリシー
+# ==================================================
+
+resource "aws_iam_role_policy_attachment" "lambda_basic_execution" {
+  count      = var.enable_monitoring ? 1 : 0
+  role       = aws_iam_role.lambda_role[0].name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+# ==================================================
+# Lambda SSM 実行ポリシー
+# ==================================================
+
+resource "aws_iam_role_policy" "lambda_ssm_policy" {
+  count = var.enable_monitoring ? 1 : 0
+  name  = "${local.lambda_role_name}-ssm-policy"
+  role  = aws_iam_role.lambda_role[0].id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "ssm:SendCommand"
+        ]
+        Resource = [
+          "arn:aws:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:instance/*",
+          "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:document/AWS-RunShellScript"
+        ]
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "ssm:GetCommandInvocation"
+        ]
+        Resource = "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:*"
+      }
+    ]
+  })
+}
+
+# ==================================================
+# Lambda Secrets Manager アクセス ポリシー
+# ==================================================
+
+resource "aws_iam_role_policy" "lambda_secrets_policy" {
+  count = var.enable_monitoring ? 1 : 0
+  name  = "${local.lambda_role_name}-secrets-policy"
+  role  = aws_iam_role.lambda_role[0].id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "secretsmanager:GetSecretValue"
+        ]
+        Resource = var.slack_token_secret_arn
+      }
+    ]
+  })
+}
+
+# ==================================================
+# Lambda 関数
+# ==================================================
+
+resource "aws_lambda_function" "ecs_agent_monitor" {
+  count            = var.enable_monitoring ? 1 : 0
+  filename         = data.archive_file.lambda_zip[0].output_path
+  function_name    = local.lambda_function_name
+  role             = aws_iam_role.lambda_role[0].arn
+  handler          = "index.lambda_handler"
+  runtime          = var.lambda_runtime
+  timeout          = var.lambda_timeout
+  source_code_hash = data.archive_file.lambda_zip[0].output_base64sha256
+
+  environment {
+    variables = {
+      SLACK_CHANNEL          = var.slack_channel
+      SLACK_TOKEN_SECRET_ARN = var.slack_token_secret_arn
+    }
+  }
+
+  tags = merge(
+    var.common_tags,
+    {
+      Name      = local.lambda_function_name
+      ManagedBy = "Terraform"
+    }
+  )
+}
+
+# ==================================================
+# Lambda 関数のソースコード
+# ==================================================
+
+resource "local_file" "lambda_source" {
+  count    = var.enable_monitoring ? 1 : 0
+  filename = "${path.module}/lambda_source/index.py"
+  content  = <<-EOF
+"""
+ECSエージェントの状態を確認し、停止していたら起動させる
+"""
+import base64
+import gzip
+import json
+import os
+import logging
+
+import boto3
+from slack_sdk import WebClient
+from slack_sdk.errors import SlackApiError
+
+# ログ設定
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+# 環境変数
+SLACK_CHANNEL = os.environ['SLACK_CHANNEL']
+SLACK_TOKEN_SECRET_ARN = os.environ['SLACK_TOKEN_SECRET_ARN']
+
+# クライアント初期化
+ssm = boto3.client('ssm')
+secrets_client = boto3.client('secretsmanager')
+
+
+def get_slack_token() -> str:
+    """
+    AWS Secrets Manager からSlack トークンを取得する
+
+    Returns:
+        str: Slack Bot Token
+    """
+    try:
+        response = secrets_client.get_secret_value(SecretId=SLACK_TOKEN_SECRET_ARN)
+        secret = json.loads(response['SecretString'])
+        return secret['slack_token']
+    except Exception as e:
+        logger.error(f"Error retrieving Slack token from Secrets Manager: {e}")
+        raise
+
+
+# Slack クライアント初期化
+slack_client = WebClient(token=get_slack_token())
+
+
+def send_slack_notification(message: str) -> None:
+    """
+    Slackに通知を送信する
+
+    Args:
+        message: 送信するメッセージ
+    """
+    try:
+        response = slack_client.chat_postMessage(
+            channel=SLACK_CHANNEL,
+            text=message,
+            username='ECS Agent Monitor',
+            icon_emoji=':robot_face:'
+        )
+        logger.info(f"Slack notification sent successfully: {response['ts']}")
+    except SlackApiError as e:
+        logger.error(f"Error sending Slack notification: {e.response['error']}")
+        raise
+
+
+def lambda_handler(event, context) -> dict:
+    """
+    Lambda関数
+
+    Args:
+        event: Lambdaイベント
+        context: Lambdaコンテキスト
+
+    Returns:
+        dict: レスポンス
+    """
+    try:
+        # base64 デコード
+        decoded_data = base64.b64decode(event['awslogs']['data'])
+
+        # gzip 解凍
+        decompressed_data = gzip.decompress(decoded_data)
+        json_data = json.loads(decompressed_data)
+
+        # ログイベントからinstance_idを取得
+        message = json.loads(json_data['logEvents'][0]['message'])
+        instance_id = message['detail']['ec2InstanceId']
+        cluster_arn = message['detail']['clusterArn']
+
+        logger.info(f"Processing ECS agent monitoring for instance: {instance_id}")
+
+        # インスタンスで実行するコマンド
+        commands = []
+
+        # ECSエージェントの状態を確認
+        commands.append('sudo systemctl status ecs')
+
+        # ECSエージェントが停止していたら起動させる
+        restart_command = '''
+            if [ $? -ne 0 ]; then
+                echo "ECS agent is not running, attempting to restart..."
+                sudo systemctl start ecs
+                if [ $? -eq 0 ]; then
+                    echo "SUCCESS: ECS agent restarted successfully"
+                else
+                    echo "FAILED: Could not restart ECS agent"
+                fi
+            else
+                echo "ECS agent is already running"
+            fi
+        '''
+        commands.append(restart_command)
+
+        # SSMコマンドを実行
+        response = ssm.send_command(
+            InstanceIds=[instance_id],
+            DocumentName='AWS-RunShellScript',
+            Parameters={
+                'commands': commands,
+            },
+        )
+
+        command_id = response['Command']['CommandId']
+        logger.info(f"SSM command sent with ID: {command_id}")
+
+        # 初期通知をSlackに送信
+        cluster_name = cluster_arn.split('/')[-1]
+        initial_message = f":warning: ECS Agent Monitor Alert\\n\\n" \
+                         f"**Instance ID:** {instance_id}\\n" \
+                         f"**Cluster:** {cluster_name}\\n" \
+                         f"**Status:** ECS agent disconnected - attempting restart\\n" \
+                         f"**Command ID:** {command_id}"
+
+        send_slack_notification(initial_message)
+
+        return {
+            'statusCode': 200,
+            'body': json.dumps({
+                'message': 'ECS agent monitoring completed successfully',
+                'instance_id': instance_id,
+                'command_id': command_id
+            })
+        }
+
+    except Exception as e:
+        logger.error(f"Error processing ECS agent monitoring: {str(e)}")
+
+        # エラー通知をSlackに送信
+        error_message = f":red_circle: ECS Agent Monitor Error\\n\\n" \
+                       f"**Error:** {str(e)}\\n" \
+                       f"**Instance ID:** {instance_id if 'instance_id' in locals() else 'Unknown'}"
+
+        try:
+            send_slack_notification(error_message)
+        except:
+            logger.error("Failed to send error notification to Slack")
+
+        return {
+            'statusCode': 500,
+            'body': json.dumps({
+                'error': str(e)
+            })
+        }
+EOF
+}
+
+# ==================================================
+# Lambda requirements.txt
+# ==================================================
+
+resource "local_file" "lambda_requirements" {
+  count    = var.enable_monitoring ? 1 : 0
+  filename = "${path.module}/lambda_source/requirements.txt"
+  content  = <<-EOF
+slack-sdk>=3.19.0
+boto3>=1.28.0
+EOF
+}
+
+# ==================================================
+# Lambda 依存関係のインストール
+# ==================================================
+
+resource "null_resource" "install_lambda_dependencies" {
+  count = var.enable_monitoring ? 1 : 0
+
+  provisioner "local-exec" {
+    command = <<-EOT
+      cd ${path.module}
+      rm -rf lambda_package
+      mkdir -p lambda_package
+      cp lambda_source/index.py lambda_package/
+      cp lambda_source/requirements.txt lambda_package/
+      cd lambda_package
+      pip install -r requirements.txt -t .
+      rm requirements.txt
+    EOT
+  }
+
+  depends_on = [local_file.lambda_source, local_file.lambda_requirements]
+
+  triggers = {
+    source_hash       = local_file.lambda_source[0].content_md5
+    requirements_hash = local_file.lambda_requirements[0].content_md5
+  }
+}
+
+# ==================================================
+# Lambda デプロイ用 ZIP ファイル
+# ==================================================
+
+data "archive_file" "lambda_zip" {
+  count       = var.enable_monitoring ? 1 : 0
+  type        = "zip"
+  source_dir  = "${path.module}/lambda_package"
+  output_path = "${path.module}/lambda_deployment.zip"
+  depends_on  = [null_resource.install_lambda_dependencies]
+}
+
+# ==================================================
+# Lambda 実行許可（CloudWatch Logs から）
+# ==================================================
+
+resource "aws_lambda_permission" "allow_cloudwatch" {
+  count         = var.enable_monitoring ? 1 : 0
+  statement_id  = "AllowExecutionFromCloudWatchLogs"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.ecs_agent_monitor[0].function_name
+  principal     = "logs.amazonaws.com"
+  source_arn    = "${aws_cloudwatch_log_group.ecs_agent_monitor[0].arn}:*"
+}
+
+# ==================================================
+# CloudWatch ログ サブスクリプション フィルター
+# ==================================================
+
+resource "aws_cloudwatch_log_subscription_filter" "ecs_agent_monitor" {
+  count           = var.enable_monitoring ? 1 : 0
+  name            = local.subscription_filter_name
+  log_group_name  = aws_cloudwatch_log_group.ecs_agent_monitor[0].name
+  filter_pattern  = var.subscription_filter_pattern
+  destination_arn = aws_lambda_function.ecs_agent_monitor[0].arn
+  depends_on      = [aws_lambda_permission.allow_cloudwatch]
+}

--- a/ecs/monitoring/terraform/main.tf
+++ b/ecs/monitoring/terraform/main.tf
@@ -20,6 +20,16 @@ locals {
 
   # サブスクリプション フィルター名
   subscription_filter_name = "${local.name_prefix}-ecs-agent-monitor-filter"
+
+  # 共通タグ（必須タグを含む）
+  common_tags = merge(
+    {
+      Project     = var.project_name
+      Environment = var.environment
+      ManagedBy   = "Terraform"
+    },
+    var.common_tags
+  )
 }
 
 # ==================================================
@@ -50,10 +60,9 @@ resource "aws_cloudwatch_event_rule" "ecs_instance_state_change" {
   state = "ENABLED"
 
   tags = merge(
-    var.common_tags,
+    local.common_tags,
     {
-      Name      = local.eventbridge_rule_name
-      ManagedBy = "Terraform"
+      Name = local.eventbridge_rule_name
     }
   )
 }
@@ -68,10 +77,9 @@ resource "aws_cloudwatch_log_group" "ecs_agent_monitor" {
   retention_in_days = var.log_retention_in_days
 
   tags = merge(
-    var.common_tags,
+    local.common_tags,
     {
-      Name      = local.log_group_name
-      ManagedBy = "Terraform"
+      Name = local.log_group_name
     }
   )
 }
@@ -109,10 +117,9 @@ resource "aws_iam_role" "lambda_role" {
   })
 
   tags = merge(
-    var.common_tags,
+    local.common_tags,
     {
-      Name      = local.lambda_role_name
-      ManagedBy = "Terraform"
+      Name = local.lambda_role_name
     }
   )
 }
@@ -205,10 +212,9 @@ resource "aws_lambda_function" "ecs_agent_monitor" {
   }
 
   tags = merge(
-    var.common_tags,
+    local.common_tags,
     {
-      Name      = local.lambda_function_name
-      ManagedBy = "Terraform"
+      Name = local.lambda_function_name
     }
   )
 }

--- a/ecs/monitoring/terraform/outputs.tf
+++ b/ecs/monitoring/terraform/outputs.tf
@@ -1,0 +1,85 @@
+# ==================================================
+# EventBridge ルール情報
+# ==================================================
+
+output "eventbridge_rule_name" {
+  description = "EventBridge ルール名"
+  value       = var.enable_monitoring ? try(aws_cloudwatch_event_rule.ecs_instance_state_change[0].name, null) : null
+}
+
+output "eventbridge_rule_arn" {
+  description = "EventBridge ルール ARN"
+  value       = var.enable_monitoring ? try(aws_cloudwatch_event_rule.ecs_instance_state_change[0].arn, null) : null
+}
+
+# ==================================================
+# CloudWatch ログ情報
+# ==================================================
+
+output "log_group_name" {
+  description = "CloudWatch ログ グループ名"
+  value       = var.enable_monitoring ? try(aws_cloudwatch_log_group.ecs_agent_monitor[0].name, null) : null
+}
+
+output "log_group_arn" {
+  description = "CloudWatch ログ グループ ARN"
+  value       = var.enable_monitoring ? try(aws_cloudwatch_log_group.ecs_agent_monitor[0].arn, null) : null
+}
+
+# ==================================================
+# Lambda 関数情報
+# ==================================================
+
+output "lambda_function_name" {
+  description = "Lambda 関数名"
+  value       = var.enable_monitoring ? try(aws_lambda_function.ecs_agent_monitor[0].function_name, null) : null
+}
+
+output "lambda_function_arn" {
+  description = "Lambda 関数 ARN"
+  value       = var.enable_monitoring ? try(aws_lambda_function.ecs_agent_monitor[0].arn, null) : null
+}
+
+output "lambda_role_name" {
+  description = "Lambda 実行 IAM ロール名"
+  value       = var.enable_monitoring ? try(aws_iam_role.lambda_role[0].name, null) : null
+}
+
+output "lambda_role_arn" {
+  description = "Lambda 実行 IAM ロール ARN"
+  value       = var.enable_monitoring ? try(aws_iam_role.lambda_role[0].arn, null) : null
+}
+
+# ==================================================
+# サブスクリプション フィルター情報
+# ==================================================
+
+output "subscription_filter_name" {
+  description = "CloudWatch ログ サブスクリプション フィルター名"
+  value       = var.enable_monitoring ? try(aws_cloudwatch_log_subscription_filter.ecs_agent_monitor[0].name, null) : null
+}
+
+output "subscription_filter_arn" {
+  description = "CloudWatch ログ サブスクリプション フィルター ARN"
+  value       = var.enable_monitoring ? try(aws_cloudwatch_log_subscription_filter.ecs_agent_monitor[0].arn, null) : null
+}
+
+# ==================================================
+# 設定情報
+# ==================================================
+
+output "cluster_arn" {
+  description = "監視対象のECSクラスターARN"
+  value       = var.cluster_arn
+}
+
+output "monitoring_enabled" {
+  description = "ECSエージェント監視が有効かどうか"
+  value       = var.enable_monitoring
+}
+
+output "slack_token_configured" {
+  description = "Slack Bot Token Secret ARNが設定されているかどうか"
+  value       = var.slack_token_secret_arn != ""
+  sensitive   = false
+}

--- a/ecs/monitoring/terraform/terraform.tfvars.example
+++ b/ecs/monitoring/terraform/terraform.tfvars.example
@@ -1,0 +1,71 @@
+# ==================================================
+# 基本設定
+# ==================================================
+
+# AWSリージョン
+aws_region = "ap-northeast-1"
+
+# プロジェクト名
+project_name = "my-project"
+
+# 環境名 (prd, rls, stg, dev)
+environment = "dev"
+
+# アプリケーション名（オプション）
+app = "web"
+
+# 共通タグ
+common_tags = {
+  Environment = "dev"
+  Project     = "my-project"
+  Application = "web"
+  Owner       = "team@example.com"
+}
+
+# ==================================================
+# ECSエージェント監視設定
+# ==================================================
+
+# リソース名のプレフィックス（オプション）
+# 指定しない場合は project_name-environment の形式で自動生成される
+# resource_name_prefix = "my-custom-prefix"
+
+# 監視対象のECSクラスターARN
+cluster_arn = "arn:aws:ecs:ap-northeast-1:123456789012:cluster/my-cluster"
+
+# Slack Bot Token を格納している AWS Secrets Manager のシークレット ARN
+slack_token_secret_arn = "arn:aws:secretsmanager:ap-northeast-1:123456789012:secret:slack-bot-token-AbCdEf"
+
+# Slack通知先チャンネル名 (例: #alerts, @user)
+slack_channel = "#alerts"
+
+# ==================================================
+# CloudWatch ログ設定
+# ==================================================
+
+# CloudWatchログ グループ名（オプション）
+# 指定しない場合は自動生成される
+# log_group_name = "/aws/events/custom-log-group"
+
+# CloudWatchログの保持期間（日）
+log_retention_in_days = 30
+
+# ==================================================
+# Lambda設定
+# ==================================================
+
+# Lambda関数のタイムアウト（秒）
+lambda_timeout = 60
+
+# Lambda関数のランタイム
+lambda_runtime = "python3.9"
+
+# ==================================================
+# フィルタリング設定
+# ==================================================
+
+# CloudWatch ログ サブスクリプション フィルターのパターン
+subscription_filter_pattern = "{ $.detail.agentConnected is false }"
+
+# ECSエージェント監視を有効にするか
+enable_monitoring = true

--- a/ecs/monitoring/terraform/variables.tf
+++ b/ecs/monitoring/terraform/variables.tf
@@ -1,0 +1,126 @@
+# ==================================================
+# 基本設定
+# ==================================================
+
+variable "aws_region" {
+  description = "AWSリージョン"
+  type        = string
+  default     = "ap-northeast-1"
+}
+
+variable "project_name" {
+  description = "プロジェクト名"
+  type        = string
+}
+
+variable "environment" {
+  description = "環境名 (prd, rls, stg, dev)"
+  type        = string
+
+  validation {
+    condition     = contains(["prd", "rls", "stg", "dev"], var.environment)
+    error_message = "environment must be one of the following values: prd, rls, stg, or dev."
+  }
+}
+
+variable "app" {
+  description = "アプリケーション名（オプション）"
+  type        = string
+  default     = ""
+}
+
+variable "common_tags" {
+  description = "共通タグ"
+  type        = map(string)
+  default     = {}
+}
+
+# ==================================================
+# ECSエージェント監視設定
+# ==================================================
+
+variable "resource_name_prefix" {
+  description = "リソース名のプレフィックス（指定しない場合は自動生成）"
+  type        = string
+  default     = ""
+}
+
+variable "cluster_arn" {
+  description = "監視対象のECSクラスターARN"
+  type        = string
+}
+
+variable "slack_channel" {
+  description = "Slack通知先チャンネル名 (例: #alerts, @user)"
+  type        = string
+  default     = "#alerts"
+}
+
+variable "slack_token_secret_arn" {
+  description = "Slack Bot Token を格納している AWS Secrets Manager のシークレット ARN"
+  type        = string
+  sensitive   = true
+}
+
+# ==================================================
+# CloudWatch ログ設定
+# ==================================================
+
+variable "log_group_name" {
+  description = "CloudWatchログ グループ名（指定しない場合は自動生成）"
+  type        = string
+  default     = ""
+}
+
+variable "log_retention_in_days" {
+  description = "CloudWatchログの保持期間（日）"
+  type        = number
+  default     = 30
+
+  validation {
+    condition     = contains([1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653], var.log_retention_in_days)
+    error_message = "log_retention_in_days must be one of the following values: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653."
+  }
+}
+
+# ==================================================
+# Lambda設定
+# ==================================================
+
+variable "lambda_timeout" {
+  description = "Lambda関数のタイムアウト（秒）"
+  type        = number
+  default     = 60
+
+  validation {
+    condition     = var.lambda_timeout >= 1 && var.lambda_timeout <= 900
+    error_message = "lambda_timeout must be between 1 and 900 seconds."
+  }
+}
+
+variable "lambda_runtime" {
+  description = "Lambda関数のランタイム"
+  type        = string
+  default     = "python3.9"
+
+  validation {
+    condition     = contains(["python3.8", "python3.9", "python3.10", "python3.11"], var.lambda_runtime)
+    error_message = "lambda_runtime must be one of the following values: python3.8, python3.9, python3.10, python3.11."
+  }
+}
+
+# ==================================================
+# フィルタリング設定
+# ==================================================
+
+variable "subscription_filter_pattern" {
+  description = "CloudWatch ログ サブスクリプション フィルターのパターン"
+  type        = string
+  default     = "{ $.detail.agentConnected is false }"
+}
+
+variable "enable_monitoring" {
+  description = "ECSエージェント監視を有効にするか"
+  type        = bool
+  default     = true
+}

--- a/ecs/monitoring/terraform/versions.tf
+++ b/ecs/monitoring/terraform/versions.tf
@@ -1,0 +1,30 @@
+# ==================================================
+# Terraform バージョン制約
+# ==================================================
+
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    archive = {
+      source  = "hashicorp/archive"
+      version = "~> 2.0"
+    }
+    local = {
+      source  = "hashicorp/local"
+      version = "~> 2.0"
+    }
+  }
+}
+
+# ==================================================
+# AWSプロバイダー設定
+# ==================================================
+
+provider "aws" {
+  region = var.aws_region
+}

--- a/ecs/monitoring/terraform/versions.tf
+++ b/ecs/monitoring/terraform/versions.tf
@@ -27,4 +27,8 @@ terraform {
 
 provider "aws" {
   region = var.aws_region
+
+  default_tags {
+    tags = local.common_tags
+  }
 }


### PR DESCRIPTION
…起動を試みる機能を実装。Slack通知機能を追加し、監視対象のECSクラスターARNやSlack Bot Tokenの設定を含む。READMEを作成し、使用方法や設定手順を詳細に記載。全体のドキュメントを整備し、Terraformの設定ファイルも新規作成。